### PR TITLE
Fix canPassStrict arguments order

### DIFF
--- a/lib/flake-utils.nix
+++ b/lib/flake-utils.nix
@@ -41,7 +41,7 @@
       locked  = builtins.mapAttrs ( id: fetchInput ) lock.nodes;
       stdArgs = locked // auto // { inherit self; };
       fetchInput = { locked, ... }: builtins.fetchTree locked;
-    in lib.canPassStrict stdArgs flake.outputs;
+    in lib.canPassStrict flake.outputs stdArgs;
     self = flake // ( flake.outputs ( inputs // extraArgs ) );
   in self;
 


### PR DESCRIPTION
It looks like the arguments got swapped in https://github.com/aakropotkin/ak-nix/commit/14d0ef49d7a11c6bef7088123ca3b7063a2a61b2 and callFlakeWith never got updated.